### PR TITLE
Add basic vulnerability scan results

### DIFF
--- a/VULNERABILITY_REPORT.md
+++ b/VULNERABILITY_REPORT.md
@@ -1,0 +1,63 @@
+# Vulnerability Report
+
+This repository contains an Android APK. A quick vulnerability check was performed using open source tools.
+
+## APKiD Results
+
+```
+[+] APKiD 3.0.0 :: from RedNaga :: rednaga.io
+[*] digital.yourway.flightclass.apk!classes.dex
+ |-> anti_vm : Build.FINGERPRINT check, Build.MANUFACTURER check, possible Build.SERIAL check
+ |-> compiler : r8
+[*] digital.yourway.flightclass.apk!classes2.dex
+ |-> anti_vm : Build.BOARD check, Build.FINGERPRINT check, Build.HARDWARE check, Build.MANUFACTURER check, Build.MODEL check, Build.PRODUCT check, Build.TAGS check, SIM operator check, network operator name check
+ |-> compiler : r8 without marker (suspicious)
+[*] digital.yourway.flightclass.apk!classes3.dex
+ |-> anti_vm : Build.MANUFACTURER check
+ |-> compiler : r8 without marker (suspicious)
+[*] digital.yourway.flightclass.apk!classes4.dex
+ |-> compiler : r8 without marker (suspicious)
+[*] digital.yourway.flightclass.apk!classes5.dex
+ |-> compiler : unknown (please file detection issue!)
+```
+
+## AndroidManifest Permissions
+
+```
+2:    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+3:    <uses-permission android:name="android.permission.DOWNLOAD_WITHOUT_NOTIFICATION"/>
+4:    <uses-permission android:name="android.permission.INTERNET"/>
+5:    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
+6:    <uses-permission android:maxSdkVersion="32" android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+7:    <uses-permission android:name="android.permission.RECORD_AUDIO"/>
+8:    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+9:    <uses-permission android:name="android.permission.VIBRATE"/>
+10:    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+32:    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
+33:    <uses-permission android:name="android.permission.WAKE_LOCK"/>
+34:    <uses-permission android:name="android.permission.CAMERA"/>
+35:    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
+36:    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO"/>
+37:    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+38:    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+39:    <uses-permission android:minSdkVersion="34" android:name="android.permission.DETECT_SCREEN_CAPTURE"/>
+40:    <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE"/>
+42:    <uses-permission android:name="digital.yourway.flightclass.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION"/>
+43:    <uses-permission android:name="com.google.android.finsky.permission.BIND_GET_INSTALL_REFERRER_SERVICE"/>
+44:    <uses-permission android:name="com.sec.android.provider.badge.permission.READ"/>
+45:    <uses-permission android:name="com.sec.android.provider.badge.permission.WRITE"/>
+46:    <uses-permission android:name="com.htc.launcher.permission.READ_SETTINGS"/>
+47:    <uses-permission android:name="com.htc.launcher.permission.UPDATE_SHORTCUT"/>
+48:    <uses-permission android:name="com.sonyericsson.home.permission.BROADCAST_BADGE"/>
+49:    <uses-permission android:name="com.sonymobile.home.permission.PROVIDER_INSERT_BADGE"/>
+50:    <uses-permission android:name="com.anddoes.launcher.permission.UPDATE_COUNT"/>
+51:    <uses-permission android:name="com.majeur.launcher.permission.UPDATE_BADGE"/>
+52:    <uses-permission android:name="com.huawei.android.launcher.permission.CHANGE_BADGE"/>
+53:    <uses-permission android:name="com.huawei.android.launcher.permission.READ_SETTINGS"/>
+54:    <uses-permission android:name="com.huawei.android.launcher.permission.WRITE_SETTINGS"/>
+55:    <uses-permission android:name="android.permission.READ_APP_BADGE"/>
+56:    <uses-permission android:name="com.oppo.launcher.permission.READ_SETTINGS"/>
+57:    <uses-permission android:name="com.oppo.launcher.permission.WRITE_SETTINGS"/>
+58:    <uses-permission android:name="me.everything.badger.permission.BADGE_COUNT_READ"/>
+59:    <uses-permission android:name="me.everything.badger.permission.BADGE_COUNT_WRITE"/>
+```

--- a/apkid_output.txt
+++ b/apkid_output.txt
@@ -1,0 +1,14 @@
+[+] APKiD 3.0.0 :: from RedNaga :: rednaga.io
+[*] digital.yourway.flightclass.apk!classes.dex
+ |-> anti_vm : Build.FINGERPRINT check, Build.MANUFACTURER check, possible Build.SERIAL check
+ |-> compiler : r8
+[*] digital.yourway.flightclass.apk!classes2.dex
+ |-> anti_vm : Build.BOARD check, Build.FINGERPRINT check, Build.HARDWARE check, Build.MANUFACTURER check, Build.MODEL check, Build.PRODUCT check, Build.TAGS check, SIM operator check, network operator name check
+ |-> compiler : r8 without marker (suspicious)
+[*] digital.yourway.flightclass.apk!classes3.dex
+ |-> anti_vm : Build.MANUFACTURER check
+ |-> compiler : r8 without marker (suspicious)
+[*] digital.yourway.flightclass.apk!classes4.dex
+ |-> compiler : r8 without marker (suspicious)
+[*] digital.yourway.flightclass.apk!classes5.dex
+ |-> compiler : unknown (please file detection issue!)

--- a/manifest_permissions.txt
+++ b/manifest_permissions.txt
@@ -1,0 +1,36 @@
+2:    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+3:    <uses-permission android:name="android.permission.DOWNLOAD_WITHOUT_NOTIFICATION"/>
+4:    <uses-permission android:name="android.permission.INTERNET"/>
+5:    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
+6:    <uses-permission android:maxSdkVersion="32" android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+7:    <uses-permission android:name="android.permission.RECORD_AUDIO"/>
+8:    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+9:    <uses-permission android:name="android.permission.VIBRATE"/>
+10:    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+32:    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
+33:    <uses-permission android:name="android.permission.WAKE_LOCK"/>
+34:    <uses-permission android:name="android.permission.CAMERA"/>
+35:    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
+36:    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO"/>
+37:    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+38:    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+39:    <uses-permission android:minSdkVersion="34" android:name="android.permission.DETECT_SCREEN_CAPTURE"/>
+40:    <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE"/>
+42:    <uses-permission android:name="digital.yourway.flightclass.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION"/>
+43:    <uses-permission android:name="com.google.android.finsky.permission.BIND_GET_INSTALL_REFERRER_SERVICE"/>
+44:    <uses-permission android:name="com.sec.android.provider.badge.permission.READ"/>
+45:    <uses-permission android:name="com.sec.android.provider.badge.permission.WRITE"/>
+46:    <uses-permission android:name="com.htc.launcher.permission.READ_SETTINGS"/>
+47:    <uses-permission android:name="com.htc.launcher.permission.UPDATE_SHORTCUT"/>
+48:    <uses-permission android:name="com.sonyericsson.home.permission.BROADCAST_BADGE"/>
+49:    <uses-permission android:name="com.sonymobile.home.permission.PROVIDER_INSERT_BADGE"/>
+50:    <uses-permission android:name="com.anddoes.launcher.permission.UPDATE_COUNT"/>
+51:    <uses-permission android:name="com.majeur.launcher.permission.UPDATE_BADGE"/>
+52:    <uses-permission android:name="com.huawei.android.launcher.permission.CHANGE_BADGE"/>
+53:    <uses-permission android:name="com.huawei.android.launcher.permission.READ_SETTINGS"/>
+54:    <uses-permission android:name="com.huawei.android.launcher.permission.WRITE_SETTINGS"/>
+55:    <uses-permission android:name="android.permission.READ_APP_BADGE"/>
+56:    <uses-permission android:name="com.oppo.launcher.permission.READ_SETTINGS"/>
+57:    <uses-permission android:name="com.oppo.launcher.permission.WRITE_SETTINGS"/>
+58:    <uses-permission android:name="me.everything.badger.permission.BADGE_COUNT_READ"/>
+59:    <uses-permission android:name="me.everything.badger.permission.BADGE_COUNT_WRITE"/>


### PR DESCRIPTION
## Summary
- run APKiD against the main APK and save the output
- decompile AndroidManifest and record declared permissions
- summarize results in `VULNERABILITY_REPORT.md`

## Testing
- `apkid digital.yourway.flightclass.apk > apkid_output.txt`
- `grep -n "uses-permission" decompiled_apk/AndroidManifest.xml > manifest_permissions.txt`


------
https://chatgpt.com/codex/tasks/task_e_683fceb444c48327aa248f04aab1c61c